### PR TITLE
fix: replace `mix-cdr.md` with `mixtape.md`

### DIFF
--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -260,7 +260,7 @@ title: My First Post
 Isn't it great?
 ```
 
-```md filename=posts/90s-mix-cdr.md
+```md filename=posts/90s-mixtape.md
 ---
 title: 90s Mixtape
 ---
@@ -396,7 +396,7 @@ Now let's make a route to actually view the post. We want these URLs to work:
 
 ```
 /posts/my-first-post
-/posts/90s-mix-cdr
+/posts/90s-mix-mixtape
 ```
 
 Instead of creating a route for every single one of our posts, we can use a "dynamic segment" in the url. Remix will parse and pass to us so we can look up the post dynamically.


### PR DESCRIPTION
Corrected name of post to match `90s-mixtape.md` as the instructions are indicating.